### PR TITLE
Allow NumberOfResultsBefore or NumberOfResultsAfter to be 0

### DIFF
--- a/Trias_JourneySupport.xsd
+++ b/Trias_JourneySupport.xsd
@@ -574,12 +574,12 @@
 			<xs:documentation>To control the number of trip results before/after a point in time. May NOT be used when departure time at origin AND arrival time at destination are set.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="NumberOfResultsBefore" type="xs:positiveInteger">
+			<xs:element name="NumberOfResultsBefore" type="xs:nonNegativeInteger">
 				<xs:annotation>
 					<xs:documentation>The desired number of trip results before the given time (at origin or destination).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="NumberOfResultsAfter" type="xs:positiveInteger">
+			<xs:element name="NumberOfResultsAfter" type="xs:nonNegativeInteger">
 				<xs:annotation>
 					<xs:documentation>The desired number of trip results after the given time (at origin or destination).</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
Before the user was forced to select at least one result after even if the user is only interested in one result before.
This commit allows to specify a 0 value, but also allows to omit the element, then the system may infer the desired value.

Backport from OJP: https://github.com/VDVde/OJP/commit/92248dd09f85461f2f7a07375b3600afba2d2378