### PR TITLE
Added ResponseContext to RefineRequests

### DIFF
--- a/Trias_IndividualTrips.xsd
+++ b/Trias_IndividualTrips.xsd
@@ -27,6 +27,11 @@
 		<xs:sequence>
 			<xs:element name="RefineParams" type="IndividualTripRefineParamStructure" minOccurs="0"/>
 			<xs:element name="IndividualRouteResult" type="RouteResultStructure"/>
+			<xs:element name="IndividualRouteResponseContext" type="TripResponseContextStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Context to hold objects, which are referenced within the response.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -51,11 +56,15 @@
 	</xs:element>
 	<xs:complexType name="IndividualRouteRefineResponseStructure">
 		<xs:annotation>
-			<xs:documentation>IndividualRouteRefine response structure</xs:documentation>
+			<xs:documentation>Context to hold objects, which are referenced within the response.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="ErrorMessage" type="ErrorMessageStructure" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="IndividualRouteResponseContext" type="TripResponseContextStructure" minOccurs="0"/>
+			<xs:element name="IndividualRouteResponseContext" type="TripResponseContextStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Context to hold objects, which are referenced within the response.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="IndividualRouteResult" type="RouteResultStructure" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>

--- a/Trias_StopEvents.xsd
+++ b/Trias_StopEvents.xsd
@@ -137,6 +137,11 @@
 					<xs:documentation>The stop event that should be refined.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="StopEventResponseContext" type="StopEventResponseContextStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Context to hold objects, which are referenced within the response.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -286,7 +291,7 @@
 			</xs:element>
 			<xs:element name="StopEventResponseContext" type="StopEventResponseContextStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Container for data that is referenced multiple times.</xs:documentation>
+					<xs:documentation>Context to hold objects, which are referenced within the response.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="StopEventResult" type="StopEventResultStructure" minOccurs="0" maxOccurs="unbounded">

--- a/Trias_TripInfo.xsd
+++ b/Trias_TripInfo.xsd
@@ -105,6 +105,11 @@
 					<xs:documentation>The TripInfo that should be refined</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="TripInfoResponseContext" type="TripInfoResponseContextStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Context to hold objects, which are referenced within the response.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -215,7 +220,7 @@
 			</xs:element>
 			<xs:element name="TripInfoResponseContext" type="TripInfoResponseContextStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Response context.</xs:documentation>
+					<xs:documentation>Context to hold objects, which are referenced within the response.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="TripInfoResult" type="TripInfoResultStructure" minOccurs="0">

--- a/Trias_Trips.xsd
+++ b/Trias_Trips.xsd
@@ -181,6 +181,11 @@
 					<xs:documentation>The trip result to be refined by the server.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="TripResponseContext" type="TripResponseContextStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Context to hold objects, which are referenced within the response.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -709,7 +714,7 @@
 			</xs:element>
 			<xs:element name="TripResponseContext" type="TripResponseContextStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Context to hold trip response objects that occur frequently.</xs:documentation>
+					<xs:documentation>Context to hold objects, which are referenced within the response.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="UnknownLegRef" type="xs:NMTOKEN" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
Added ResponseContext to `IndividualRouteRefineRequest` and `StopEventRefineRequest`.

Additionally the documentation for all ResponseContexts is unified.