### PR TITLE
Callwise occupancy and 3-level occupancy

### DIFF
--- a/Trias_JourneySupport.xsd
+++ b/Trias_JourneySupport.xsd
@@ -191,11 +191,9 @@
 			<xs:documentation>Passenger load status of a vehicle.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:NMTOKEN">
-			<xs:enumeration value="manySeatsAvailable"/>
-			<xs:enumeration value="fewSeatsAvailable"/>
-			<xs:enumeration value="noSeatsAvailable"/>
-			<xs:enumeration value="standingAvailable"/>
-			<xs:enumeration value="full"/>
+			<xs:enumeration value="low"/>
+			<xs:enumeration value="moderate"/>
+			<xs:enumeration value="high"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:annotation>
@@ -321,6 +319,11 @@
 					<xs:documentation>Alighting will not be allowed at this stop of this journey.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="Occupancy" type="OccupancyEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Level of occupancy in the vehicle in the moment of leaving the stop. If omitted, not known.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:group>
 	<xs:complexType name="DatedCallAtLocationStructure">
@@ -371,7 +374,7 @@
 			</xs:element>
 			<xs:element name="Occupancy" type="OccupancyEnumeration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Level of occupancy in the vehicle. If omitted, not known.</xs:documentation>
+					<xs:documentation>Level of maximum occupancy in the vehicle. If omitted, not known.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>

--- a/Trias_JourneySupport.xsd
+++ b/Trias_JourneySupport.xsd
@@ -188,7 +188,7 @@
 	</xs:complexType>
 	<xs:simpleType name="OccupancyEnumeration">
 		<xs:annotation>
-			<xs:documentation>Passenger load status of a vehicle.</xs:documentation>
+			<xs:documentation>Passenger load status of a vehicle, according VDV 7052.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:NMTOKEN">
 			<xs:enumeration value="low"/>
@@ -321,7 +321,7 @@
 			</xs:element>
 			<xs:element name="Occupancy" type="OccupancyEnumeration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Level of occupancy in the vehicle in the moment of leaving the stop. If omitted, not known.</xs:documentation>
+					<xs:documentation>Level of occupancy in the vehicle when leaving the stop. If omitted, not known.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -374,7 +374,7 @@
 			</xs:element>
 			<xs:element name="Occupancy" type="OccupancyEnumeration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Level of maximum occupancy in the vehicle. If omitted, not known.</xs:documentation>
+					<xs:documentation>Level of occupancy in the vehicle during the trip (leg). The maximum during the trip (leg) should be considered. If omitted, not known.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>

--- a/Trias_Trips.xsd
+++ b/Trias_Trips.xsd
@@ -324,6 +324,11 @@
 					<xs:documentation>Trip distance.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="Occupancy" type="OccupancyEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Level of occupancy during the trip. The maximum during the trip should be considered. If omitted, not known.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="TripLeg" type="TripLegStructure" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Legs of the trip</xs:documentation>


### PR DESCRIPTION
Changed OccupancyEnumeration to a 3-level model "low", "moderate", "high". Added Occupancy to the CallStopStatusGroup and thus to LegBoard/Intermediate/Alight structure.