### PR TITLE
FaresParam for TripRefine

### DIFF
--- a/Trias_Trips.xsd
+++ b/Trias_Trips.xsd
@@ -225,6 +225,11 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:group ref="TripContentFilterGroup"/>
+			<xs:element name="FaresParam" type="FaresParamStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Parameters for fare calculation. Only sensible, if IncludeFares is set.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>


### PR DESCRIPTION
TripRefine is intended to be capable of adding fare information to a trip. For this purpose TripRefineRequest should contain fares parameters.